### PR TITLE
fix: correct module path in binding_test.go

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
-	tree_sitter_dart "github.com/tree-sitter/tree-sitter-dart/bindings/go"
+	tree_sitter_dart "github.com/nielsenko/tree-sitter-dart/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {


### PR DESCRIPTION
The generated test imports `github.com/tree-sitter/tree-sitter-dart/bindings/go`, but the repo lives at `github.com/nielsenko/tree-sitter-dart` — so `go mod tidy` fails trying to resolve a nonexistent module.

This is the template default from tree-sitter's Go binding codegen; it just needs to point at the actual repo.